### PR TITLE
Allow bestEstimate offset and for forecast interval to be different than step size 

### DIFF
--- a/rolodex/forecast/forecast_index.py
+++ b/rolodex/forecast/forecast_index.py
@@ -173,6 +173,8 @@ class BestEstimate:
     # TODO: `since` could be a timedelta relative to `asof`.
     # since: pd.Timestamp | None = None
     asof: pd.Timestamp | None = None
+    # Start at this step.
+    offset: int = 0
 
     def __post_init__(self):
         if self.asof is not None and self.asof < self.since:
@@ -213,16 +215,17 @@ class BestEstimate:
                 np.repeat(i, n_best_steps_per_forecast[i])
                 for i in range(len(time_index)- 1)
             ] + [
-                np.repeat(last_index, nsteps),
+                np.repeat(last_index, nsteps - self.offset),
             ]
         )
 
+        # assume that there are enough steps to fulfill the requested offset
         needed_step_idxrs = np.concatenate(
             [
-                np.arange(n_best_steps_per_forecast[i])
+                np.arange(self.offset, n_best_steps_per_forecast[i] + self.offset)
                 for i in range(len(time_index) - 1)
             ] + [
-                np.arange(nsteps)
+                np.arange(self.offset, nsteps)
             ]
         )
 


### PR DESCRIPTION
Here's an example:

```python
import numpy as np
import pandas as pd
import xarray as xr

import rolodex.forecast
from rolodex.forecast import BestEstimate, ForecastIndex


xr.set_options(keep_attrs=True, display_expand_indexes=True)

ds = xr.Dataset(attrs={"description": "Example non-matching step and forecast interval dataset"})
shape = {"x": 40, "time": 10, "step": int(24 * 3)}
ds["foo"] = (("x", "time", "step"), np.ones(tuple(shape.values())))
ds["time"] = (
    "time",
    np.concat([
        pd.date_range("2023-01-01", freq="d", periods=int(shape["time"]/2)),
        pd.date_range("2023-01-07", freq="d", periods=int(shape["time"]/2))
    ]),
    {"standard_name": "forecast_reference_time"},
)
ds["step"] = (
    "step",
    pd.to_timedelta(np.arange(0, shape["step"]), unit="hours"),
    {"standard_name": "forecast_period"},
)

ds["foo"] = xr.where(
    # With this ordering, attrs gets preserved
    ~((ds.time.dt.hour % 6 != 0) & (ds.step.dt.total_seconds() / 3600 > 18)),
    ds.foo,
    np.nan,
)

ds.coords["valid_time"] = rolodex.forecast.create_lazy_valid_time_variable(
    reference_time=ds.time, period=ds.step
)

# set the new index
newds = ds.drop_indexes(["time", "step"]).set_xindex(
    ["time", "step", "valid_time"], ForecastIndex
)

subset = newds.sel(valid_time=BestEstimate(offset=2))
assert not subset.foo.isnull().any().item()

# ensure that there is a valid time for every hour in the dataset
assert (np.diff(subset.valid_time) == pd.Timedelta("1h")).all()
subset
```